### PR TITLE
fix: show open positions (DB fallback) + correct backtest date unit & run-config validation

### DIFF
--- a/client/src/pages/Backtest.tsx
+++ b/client/src/pages/Backtest.tsx
@@ -1,27 +1,20 @@
-import { useEffect, useState } from "react";
-import { motion } from "framer-motion";
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from "recharts";
-import {
-  FlaskConical,
-  Play,
-  Trash2,
-  RefreshCw,
-  TrendingUp,
-  TrendingDown,
-  Target,
-  Percent,
-  Activity,
-} from "lucide-react";
+/* ===========================================================================
+   QUORUM — Backtest
+   "Prove it on history before it touches capital."
+
+   Faithful port of redesign/secondary.jsx → Backtest(), wired to the REAL
+   backend (/api/backtest/*). Preserves every feature of the previous page:
+   run config (symbols / dates / capital / fees / leverage / strategy / AI
+   model), live concierge model-sync, previous-runs list with select + delete,
+   rich metric tiles, equity + drawdown charts, monthly returns, and a
+   trade-return distribution. No mock data — empty states stand in until a run
+   produces results.
+   =========================================================================== */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   listBacktests,
+  stopBacktest,
   startBacktest,
   getBacktestMetrics,
   getBacktestEquity,
@@ -29,105 +22,318 @@ import {
   deleteBacktest,
   getStrategies,
 } from "../lib/api";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { useConciergeAccounts } from "../hooks/useConciergeAccounts";
+import { chartLink } from "../lib/deepLinks";
+import { displaySymbol } from "../lib/symbol";
+import { Ic } from "../quorum/icons";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { GlassCard } from "@/components/ui/glass-card";
-import { GlowBadge } from "@/components/ui/glow-badge";
-import { StatCard, ProgressStat } from "@/components/ui/stat-card";
-import { SpotlightCard } from "@/components/ui/spotlight-card";
+  AreaPlus,
+  Underwater,
+  MonthlyBars,
+  ReturnHistogram,
+  type MonthlyBar,
+} from "../quorum/analytics-charts";
 import { useConfirm, useAlert } from "@/components/ui/confirm-modal";
-import { MobileCardTable } from "@/components/ui/mobile-card-table";
+
+/* ----------------------------------------------------------------------------
+   Backend contract (server/backtest/types.go + api/server.go)
+   ---------------------------------------------------------------------------- */
 
 interface BacktestConfig {
-  symbols: string[];
-  initial_balance: number;
-  start_ts: number;
-  end_ts: number;
+  run_id?: string;
+  name?: string;
+  symbols?: string[];
+  timeframes?: string[];
+  decision_timeframe?: string;
+  initial_balance?: number;
+  start_ts?: number; // unix milliseconds
+  end_ts?: number; // unix milliseconds
+  fee_bps?: number;
+  slippage_bps?: number;
+  btc_eth_leverage?: number;
+  altcoin_leverage?: number;
 }
 
 interface BacktestRun {
   run_id: string;
+  name?: string;
   status: string;
-  config: BacktestConfig;
-  started_at: string;
-  completed_at: string;
-  current_equity: number;
-  progress: number;
+  config?: BacktestConfig;
+  started_at?: string;
+  completed_at?: string;
+  current_equity?: number;
+  progress?: number;
   error?: string;
 }
 
 interface BacktestMetrics {
   total_return: number;
   total_return_pct: number;
+  max_drawdown: number;
+  max_drawdown_pct: number;
+  sharpe_ratio: number;
+  sortino_ratio: number;
   win_rate: number;
+  profit_factor: number;
   total_trades: number;
   winning_trades: number;
   losing_trades: number;
-  sharpe_ratio: number;
-  max_drawdown: number;
-  max_drawdown_pct: number;
   avg_win: number;
   avg_loss: number;
-  profit_factor: number;
+  largest_win: number;
+  largest_loss: number;
+  avg_hold_time_hours: number;
   final_equity: number;
 }
 
+// GET /api/backtest/{id}/equity → { equity_curve: EquityPoint[] }
 interface EquityPoint {
-  timestamp: string;
+  timestamp: number; // unix milliseconds
   equity: number;
-}
-
-interface Trade {
-  timestamp: string;
-  symbol: string;
-  side: string;
-  entry_price: number;
-  exit_price: number;
+  available: number;
   pnl: number;
-  pnl_percent: number;
+  pnl_pct: number;
+  drawdown_pct: number; // ≤ 0
+  cycle: number;
 }
 
+// GET /api/backtest/{id}/trades → { trades: TradeEvent[] }
+interface TradeEvent {
+  timestamp: number; // unix milliseconds
+  symbol: string;
+  action: string;
+  side: string;
+  quantity: number;
+  price: number;
+  fee: number;
+  realized_pnl: number;
+  leverage: number;
+  cycle: number;
+  note?: string;
+}
+
+interface StrategyLite {
+  id: string;
+  name: string;
+}
+
+// An AI model choice derived from a Quota Concierge account.
+interface ModelOption {
+  id: string; // account id — sent as ai_model
+  label: string; // e.g. "Personal MAX (Claude)"
+  provider: string; // account kind, e.g. "claude"
+}
+
+const CHART_SETUP_DRAFT_STORAGE_KEY = "ahh.chart.setupDraft";
+const BACKTEST_TIMEFRAMES = ["1m", "5m", "15m", "30m", "1h", "4h", "1d"] as const;
+
+interface ChartSetupDraft {
+  symbol?: string;
+  interval?: string;
+  call?: string;
+  headline?: string;
+}
+
+function readChartSetupDraft(): ChartSetupDraft | null {
+  try {
+    const raw = localStorage.getItem(CHART_SETUP_DRAFT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as ChartSetupDraft) : null;
+  } catch {
+    return null;
+  }
+}
+
+function isBacktestTimeframe(value: string): value is (typeof BACKTEST_TIMEFRAMES)[number] {
+  return (BACKTEST_TIMEFRAMES as readonly string[]).includes(value);
+}
+
+/* ----------------------------------------------------------------------------
+   Formatting helpers (local — keep the editorial mono look of the mockup)
+   ---------------------------------------------------------------------------- */
+const m$ = (n: number, d = 2) =>
+  (n < 0 ? "-$" : "$") +
+  Math.abs(n).toLocaleString("en-US", {
+    minimumFractionDigits: d,
+    maximumFractionDigits: d,
+  });
+const sg = (n: number, d = 2) =>
+  (n >= 0 ? "+" : "−") + Math.abs(n).toFixed(d);
+
+function fmtTs(ts?: number): string {
+  if (!ts) return "—";
+  const ms = ts > 1_000_000_000_000 ? ts : ts * 1000;
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function fmtRange(cfg?: BacktestConfig): string {
+  if (!cfg?.start_ts || !cfg?.end_ts) return "—";
+  return `${fmtTs(cfg.start_ts)} — ${fmtTs(cfg.end_ts)}`;
+}
+
+// Convert a yyyy-mm-dd date input to unix milliseconds (UTC midnight).
+function dateToTs(d: string): number {
+  if (!d) return 0;
+  const ms = Date.parse(d + "T00:00:00Z");
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+// Bucket an equity curve into calendar-month % returns for the monthly bars.
+function monthlyReturns(curve: EquityPoint[]): MonthlyBar[] {
+  if (curve.length < 2) return [];
+  const buckets = new Map<string, { first: number; last: number; label: string }>();
+  for (const p of curve) {
+    const d = new Date(p.timestamp); // backend timestamps are unix milliseconds
+    const key = `${d.getUTCFullYear()}-${String(d.getUTCMonth()).padStart(2, "0")}`;
+    const label = d.toLocaleDateString(undefined, { month: "short" });
+    const b = buckets.get(key);
+    if (b) b.last = p.equity;
+    else buckets.set(key, { first: p.equity, last: p.equity, label });
+  }
+  return Array.from(buckets.values()).map((b) => ({
+    m: b.label,
+    pct: b.first ? Math.round((b.last / b.first - 1) * 1000) / 10 : 0,
+  }));
+}
+
+/* ----------------------------------------------------------------------------
+   Component
+   ---------------------------------------------------------------------------- */
 export default function Backtest() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const setupAppliedRef = useRef(false);
   const [runs, setRuns] = useState<BacktestRun[]>([]);
   const [selectedRun, setSelectedRun] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<BacktestMetrics | null>(null);
   const [equityCurve, setEquityCurve] = useState<EquityPoint[]>([]);
-  const [trades, setTrades] = useState<Trade[]>([]);
-  const [strategies, setStrategies] = useState<any[]>([]);
+  const [trades, setTrades] = useState<TradeEvent[]>([]);
+  const [strategies, setStrategies] = useState<StrategyLite[]>([]);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [setupSource, setSetupSource] = useState<string | null>(null);
   const { confirm, ConfirmDialog } = useConfirm();
   const { alert, AlertDialog } = useAlert();
 
-  // Form state
-  const [formData, setFormData] = useState({
+  // AI model options sourced live from the Quota Concierge (Claude MAX
+  // accounts). The hook polls + refreshes on focus/visibility/`concierge:changed`
+  // so newly-added accounts appear without an app restart.
+  const { accounts: conciergeAccounts, refresh: refreshModels } =
+    useConciergeAccounts();
+  const modelOptions = useMemo<ModelOption[]>(() => {
+    const fallback: ModelOption[] = [
+      { id: "claude", label: "Claude MAX", provider: "claude" },
+    ];
+    const options: ModelOption[] = conciergeAccounts
+      .filter((a) => a && a.id)
+      .map((a) => {
+        const kind: string = a.kind || "claude";
+        const kindLabel = kind.charAt(0).toUpperCase() + kind.slice(1);
+        return {
+          id: String(a.id),
+          label: `${a.label || kindLabel} (${kindLabel})`,
+          provider: kind,
+        };
+      });
+    return options.length > 0 ? options : fallback;
+  }, [conciergeAccounts]);
+
+  // Run-config form state.
+  const [form, setForm] = useState({
+    name: "Conservative Trend",
     symbols: "BTCUSDT,ETHUSDT",
+    timeframe: "15m",
     start_date: "",
     end_date: "",
-    initial_capital: 10000,
+    initial_capital: 3000,
+    btc_eth_leverage: 10,
+    altcoin_leverage: 20,
+    fee_bps: 5,
+    slippage_bps: 2,
     strategy_id: "",
-    ai_model: "deepseek/deepseek-v3.2",
+    ai_model: "",
   });
 
   useEffect(() => {
-    loadData();
+    void loadData();
   }, []);
 
+  // SPEC-26: Chart setup handoff. Review-only: prefill the form, but never run
+  // a backtest by navigation. The user still chooses a date range and clicks Run.
   useEffect(() => {
-    if (selectedRun) {
-      loadRunData(selectedRun);
-    }
+    if (setupAppliedRef.current) return;
+    const rawSymbol = searchParams.get("setup_symbol");
+    if (!rawSymbol) return;
+    const symbol = rawSymbol.trim().toUpperCase();
+    if (!symbol) return;
+
+    setupAppliedRef.current = true;
+    const draft = readChartSetupDraft();
+    const interval = (searchParams.get("setup_interval") || draft?.interval || "").trim();
+    const label = `${displaySymbol(symbol)}${interval ? ` · ${interval}` : ""}`;
+    const call = draft?.call ? ` · ${String(draft.call).replace(/_/g, " ")}` : "";
+
+    setSetupSource(`Loaded from Chart setup: ${label}${call}`);
+    setForm((f) => ({
+      ...f,
+      name: draft?.headline ? `Chart setup: ${draft.headline.slice(0, 80)}` : `Chart setup: ${label}`,
+      symbols: symbol,
+      timeframe: isBacktestTimeframe(interval) ? interval : f.timeframe,
+    }));
+
+    const next = new URLSearchParams(searchParams);
+    next.delete("setup_symbol");
+    next.delete("setup_interval");
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  // Default to the first available model, and keep the selection valid if the
+  // currently-picked account disappears from the live list.
+  useEffect(() => {
+    setForm((f) =>
+      modelOptions.some((m) => m.id === f.ai_model)
+        ? f
+        : { ...f, ai_model: modelOptions[0].id }
+    );
+  }, [modelOptions]);
+
+  useEffect(() => {
+    if (selectedRun) void loadRunData(selectedRun);
   }, [selectedRun]);
+
+  const formSymbols = useMemo(
+    () =>
+      form.symbols
+        .split(",")
+        .map((s) => s.trim().toUpperCase())
+        .filter(Boolean),
+    [form.symbols]
+  );
+  const formStartTs = useMemo(() => dateToTs(form.start_date), [form.start_date]);
+  const formEndTs = useMemo(() => dateToTs(form.end_date), [form.end_date]);
+  const hasRunnableConfig =
+    formSymbols.length > 0 &&
+    formStartTs > 0 &&
+    formEndTs > formStartTs &&
+    Number(form.initial_capital) > 0 &&
+    Number(form.fee_bps) >= 0 &&
+    Number(form.fee_bps) <= 1000 &&
+    Number(form.slippage_bps) >= 0 &&
+    Number(form.slippage_bps) <= 1000 &&
+    Number(form.btc_eth_leverage) >= 1 &&
+    Number(form.btc_eth_leverage) <= 125 &&
+    Number(form.altcoin_leverage) >= 1 &&
+    Number(form.altcoin_leverage) <= 125;
+  const canRunBacktest = hasRunnableConfig && !creating;
+  const runDisabledTitle = hasRunnableConfig
+    ? "Run backtest"
+    : "Need ≥1 symbol, valid dates, capital > 0, fees 0–1000 bps, slippage 0–1000 bps, leverage 1–125×";
 
   const loadData = async () => {
     try {
@@ -135,7 +341,7 @@ export default function Backtest() {
         listBacktests().catch(() => ({ data: { backtests: [] } })),
         getStrategies().catch(() => ({ data: { strategies: [] } })),
       ]);
-      const backtests = runsRes.data.backtests || [];
+      const backtests: BacktestRun[] = runsRes.data.backtests || [];
       setRuns(backtests);
       setStrategies(strategiesRes.data.strategies || []);
       if (backtests.length > 0 && !selectedRun) {
@@ -152,51 +358,71 @@ export default function Backtest() {
     try {
       const [metricsRes, equityRes, tradesRes] = await Promise.all([
         getBacktestMetrics(runId).catch(() => ({ data: null })),
-        getBacktestEquity(runId).catch(() => ({ data: { equity: [] } })),
+        getBacktestEquity(runId).catch(() => ({ data: {} })),
         getBacktestTrades(runId).catch(() => ({ data: { trades: [] } })),
       ]);
-      setMetrics(metricsRes.data);
-      setEquityCurve(equityRes.data.equity || []);
-      setTrades(tradesRes.data.trades || []);
+      setMetrics(metricsRes.data as BacktestMetrics | null);
+      // Backend returns { equity_curve: [...] }; tolerate a legacy { equity: [...] }.
+      const eq =
+        (equityRes.data as any)?.equity_curve ||
+        (equityRes.data as any)?.equity ||
+        [];
+      setEquityCurve(eq as EquityPoint[]);
+      setTrades(((tradesRes.data as any)?.trades || []) as TradeEvent[]);
     } catch (err) {
       console.error("Failed to load run data:", err);
     }
   };
 
   const handleStartBacktest = async () => {
+    setError(null);
+    if (formSymbols.length === 0) {
+      setError("Enter at least one symbol before running a backtest.");
+      return;
+    }
+    if (!formStartTs || !formEndTs || formEndTs <= formStartTs) {
+      setError("Choose a valid start date and an end date after it.");
+      return;
+    }
     setCreating(true);
     try {
-      const data = {
-        symbols: formData.symbols.split(",").map((s) => s.trim()),
-        start_date: formData.start_date,
-        end_date: formData.end_date,
-        initial_capital: formData.initial_capital,
-        strategy_id: formData.strategy_id,
-        ai_model: formData.ai_model,
+      // Map the form onto the real backtest.Config (snake_case JSON tags).
+      const payload = {
+        name: form.name,
+        symbols: formSymbols,
+        decision_timeframe: form.timeframe,
+        timeframes: [form.timeframe],
+        start_ts: formStartTs,
+        end_ts: formEndTs,
+        initial_balance: Number(form.initial_capital),
+        fee_bps: Number(form.fee_bps),
+        slippage_bps: Number(form.slippage_bps),
+        btc_eth_leverage: Number(form.btc_eth_leverage),
+        altcoin_leverage: Number(form.altcoin_leverage),
+        // Preserved passthrough — the engine ignores unknown keys, but these
+        // keep the strategy + model selection in the request for any consumer.
+        strategy_id: form.strategy_id,
+        ai_model: form.ai_model,
       };
-      const res = await startBacktest(data);
-      setSelectedRun(res.data.run_id);
+      const res = await startBacktest(payload);
+      const newId = res.data?.run_id;
+      if (newId) setSelectedRun(newId);
       await loadData();
     } catch (err: any) {
-      alert({
-        title: "Error",
-        description: err.response?.data?.error || "Failed to start backtest",
-        variant: "danger",
-      });
+      setError(err?.response?.data?.error || "Failed to start backtest");
     } finally {
       setCreating(false);
     }
   };
 
   const handleDeleteBacktest = async (runId: string) => {
-    const confirmed = await confirm({
-      title: "Delete Backtest",
-      description:
-        "Are you sure you want to delete this backtest? This action cannot be undone.",
+    const ok = await confirm({
+      title: "Delete backtest run",
+      description: "Delete this backtest run and its results? This cannot be undone.",
       confirmText: "Delete",
       variant: "danger",
     });
-    if (!confirmed) return;
+    if (!ok) return;
     try {
       await deleteBacktest(runId);
       if (selectedRun === runId) {
@@ -206,614 +432,717 @@ export default function Backtest() {
         setTrades([]);
       }
       await loadData();
-    } catch (err) {
-      console.error("Failed to delete backtest:", err);
+    } catch (err: any) {
+      alert({
+        title: "Error",
+        description: err.response?.data?.error || "Failed to delete backtest",
+        variant: "danger",
+      });
     }
   };
 
-  const currentRun = runs.find((r) => r.run_id === selectedRun);
+  // Stop a running backtest (wires the existing /backtest/{id}/stop route).
+  const handleStopBacktest = async (runId: string) => {
+    const ok = await confirm({
+      title: "Stop backtest run",
+      description: "Stop this running backtest? Any partial results may be incomplete.",
+      confirmText: "Stop",
+      variant: "warning",
+    });
+    if (!ok) return;
+    try {
+      await stopBacktest(runId);
+      await loadData();
+    } catch (err: any) {
+      alert({
+        title: "Error",
+        description: err.response?.data?.error || "Failed to stop backtest",
+        variant: "danger",
+      });
+    }
+  };
 
+  // While any run is in progress, poll so its status + progress meter advance without a
+  // manual refresh. Stops polling once nothing is running.
+  const anyRunning = runs.some((r) => r.status === "running");
+  useEffect(() => {
+    if (!anyRunning) return;
+    const t = setInterval(() => {
+      void loadData();
+    }, 4000);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anyRunning]);
+
+  const currentRun = runs.find((r) => r.run_id === selectedRun) || null;
+
+  /* ---- Derived view-model ---- */
+  const equitySeries = useMemo(
+    () => equityCurve.map((p) => p.equity),
+    [equityCurve]
+  );
+  const drawdownSeries = useMemo(
+    () => equityCurve.map((p) => p.drawdown_pct),
+    [equityCurve]
+  );
+  const monthly = useMemo(() => monthlyReturns(equityCurve), [equityCurve]);
+  // Trade returns as % of starting capital — the honest proxy available from
+  // execution events (the backend exposes realized_pnl, not per-trade entry/exit).
+  const tradeReturns = useMemo(() => {
+    const base = currentRun?.config?.initial_balance || form.initial_capital || 1;
+    return trades
+      .filter((t) => t.realized_pnl !== 0)
+      .map((t) => Math.round((t.realized_pnl / base) * 1000) / 10);
+  }, [trades, currentRun, form.initial_capital]);
+  const closedCount = tradeReturns.length;
+
+  const minDrawdown = drawdownSeries.length ? Math.min(...drawdownSeries) : 0;
+
+  // avgRR and expectancy are derived from the metric primitives the backend
+  // provides (it doesn't ship avg_rr / expectancy / exposure directly).
+  const avgRR = useMemo(() => {
+    if (!metrics) return 0;
+    const loss = Math.abs(metrics.avg_loss);
+    return loss > 0 ? metrics.avg_win / loss : 0;
+  }, [metrics]);
+  const expectancyR = useMemo(() => {
+    if (!metrics) return 0;
+    const loss = Math.abs(metrics.avg_loss);
+    if (loss <= 0) return 0;
+    const wr = metrics.win_rate / 100;
+    const expDollars = wr * metrics.avg_win - (1 - wr) * loss;
+    return expDollars / loss; // expressed in R
+  }, [metrics]);
+
+  const hasResults = !!metrics && equityCurve.length > 0;
+
+  // Metric tiles — every metric the task calls for: return, sharpe, sortino,
+  // maxDD, winRate, profitFactor, trades, avgRR, expectancy (+ avg hold to
+  // round out the grid-4 to a clean 4+4+2). avgRR / expectancy are derived;
+  // the rest come straight off the backend Metrics struct.
+  const tiles: Array<[string, string, string]> = metrics
+    ? [
+        ["Net return", sg(metrics.total_return_pct) + "%", metrics.total_return_pct >= 0 ? "var(--up)" : "var(--down)"],
+        ["Sharpe", metrics.sharpe_ratio.toFixed(2), "var(--text)"],
+        ["Sortino", metrics.sortino_ratio.toFixed(2), "var(--text)"],
+        ["Max drawdown", "−" + Math.abs(metrics.max_drawdown_pct).toFixed(1) + "%", "var(--down)"],
+        ["Win rate", metrics.win_rate.toFixed(0) + "%", "var(--text)"],
+        ["Profit factor", metrics.profit_factor.toFixed(2), "var(--text)"],
+        ["Trades", String(metrics.total_trades), "var(--text)"],
+        ["Avg R:R", avgRR.toFixed(2), "var(--accent-2)"],
+        ["Expectancy", sg(expectancyR, 2) + "R", expectancyR >= 0 ? "var(--up)" : "var(--down)"],
+        ["Avg hold", metrics.avg_hold_time_hours > 0 ? metrics.avg_hold_time_hours.toFixed(1) + "h" : "—", "var(--text)"],
+      ]
+    : [];
+
+  // Run-configuration sidebar rows (echo the selected run, else the live form).
+  const cfg = currentRun?.config;
+  const configRows: Array<[string, string]> = [
+    ["Strategy", currentRun?.name || cfg?.name || form.name],
+    ["Symbols", (cfg?.symbols || form.symbols.split(",").map((s) => s.trim())).map(displaySymbol).join(" · ")],
+    ["Date range", cfg ? fmtRange(cfg) : form.start_date && form.end_date ? `${form.start_date} — ${form.end_date}` : "—"],
+    ["Timeframe", cfg?.decision_timeframe || form.timeframe],
+    ["Starting capital", m$(cfg?.initial_balance ?? form.initial_capital, 0)],
+    ["Leverage", `${cfg?.btc_eth_leverage ?? form.btc_eth_leverage}× BTC/ETH · ${cfg?.altcoin_leverage ?? form.altcoin_leverage}× alt`],
+    ["Fees", `${((cfg?.fee_bps ?? form.fee_bps) / 100).toFixed(2)}% taker · ${((cfg?.slippage_bps ?? form.slippage_bps) / 100).toFixed(2)}% slip`],
+  ];
+
+  const set = <K extends keyof typeof form>(k: K, v: (typeof form)[K]) =>
+    setForm((f) => ({ ...f, [k]: v }));
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    fontFamily: "var(--font-mono)",
+    fontSize: 12.5,
+    padding: "8px 11px",
+    border: "1px solid var(--line)",
+    borderRadius: 7,
+    background: "var(--surface-2)",
+    color: "var(--text)",
+    outline: "none",
+  };
+
+  /* ---- Loading skeleton ---- */
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen">
-        <div className="flex flex-col items-center gap-4">
-          <div className="relative w-16 h-16 flex items-center justify-center">
-            <motion.div
-              className="absolute inset-0 border-4 border-primary/20 rounded-full"
-              animate={{ opacity: [0.3, 0.8, 0.3] }}
-              transition={{
-                duration: 1.5,
-                repeat: Infinity,
-                ease: "easeInOut",
-              }}
-            />
-            <motion.div
-              className="w-8 h-8 bg-primary/20 rounded-lg flex items-center justify-center"
-              animate={{ opacity: [0.5, 1, 0.5] }}
-              transition={{
-                duration: 1.5,
-                repeat: Infinity,
-                ease: "easeInOut",
-              }}
-            >
-              <div className="w-4 h-4 bg-primary rounded" />
-            </motion.div>
+      <div className="page">
+        <div className="page-head">
+          <div>
+            <h1 className="page-title">Backtest</h1>
+            <p className="page-desc">Prove it on history before it touches capital</p>
           </div>
-          <span className="text-muted-foreground">Loading backtests...</span>
+        </div>
+        <div className="panel panel-pad" style={{ textAlign: "center", color: "var(--text-3)" }}>
+          <span className="row" style={{ justifyContent: "center", gap: 10 }}>
+            <span className="dot live" />
+            Loading backtests…
+          </span>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="p-4 lg:p-6 space-y-4 lg:space-y-6">
-      {/* Header */}
-      <div className="flex justify-between items-start gap-4">
-        <motion.div
-          initial={{ opacity: 0, x: -20 }}
-          animate={{ opacity: 1, x: 0 }}
-        >
-          <h1 className="text-2xl lg:text-3xl font-bold text-gradient flex items-center gap-3">
-            <FlaskConical className="w-6 h-6 lg:w-8 lg:h-8" />
-            Backtesting
-          </h1>
-          <p className="text-sm lg:text-base text-muted-foreground">
-            Test your strategies on historical data
-          </p>
-        </motion.div>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={loadData}
-          className="glass"
-        >
-          <RefreshCw className="h-4 w-4" />
-        </Button>
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-3">
-        {/* Configuration Panel */}
-        <GlassCard className="lg:col-span-1 p-0 overflow-hidden">
-          <div className="p-4 border-b border-white/5">
-            <h2 className="font-semibold">New Backtest</h2>
-            <p className="text-sm text-muted-foreground">Configure and run</p>
-          </div>
-
-          <div className="p-4 space-y-4">
-            <div className="space-y-2">
-              <Label>Symbols (comma-separated)</Label>
-              <Input
-                value={formData.symbols}
-                onChange={(e) =>
-                  setFormData({ ...formData, symbols: e.target.value })
-                }
-                placeholder="BTCUSDT,ETHUSDT"
-                className="glass"
-              />
-            </div>
-
-            <div className="grid grid-cols-2 gap-2">
-              <div className="space-y-2">
-                <Label>Start Date</Label>
-                <Input
-                  type="date"
-                  value={formData.start_date}
-                  onChange={(e) =>
-                    setFormData({ ...formData, start_date: e.target.value })
-                  }
-                  className="glass"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>End Date</Label>
-                <Input
-                  type="date"
-                  value={formData.end_date}
-                  onChange={(e) =>
-                    setFormData({ ...formData, end_date: e.target.value })
-                  }
-                  className="glass"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label>Initial Capital ($)</Label>
-              <Input
-                type="number"
-                value={formData.initial_capital}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    initial_capital: Number(e.target.value),
-                  })
-                }
-                className="glass"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label>Strategy</Label>
-              <Select
-                value={formData.strategy_id}
-                onValueChange={(v) =>
-                  setFormData({ ...formData, strategy_id: v })
-                }
-              >
-                <SelectTrigger className="glass">
-                  <SelectValue placeholder="Select strategy" />
-                </SelectTrigger>
-                <SelectContent>
-                  {strategies.map((s) => (
-                    <SelectItem key={s.id} value={s.id}>
-                      {s.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label>AI Model</Label>
-              <Select
-                value={formData.ai_model}
-                onValueChange={(v) => setFormData({ ...formData, ai_model: v })}
-              >
-                <SelectTrigger className="glass">
-                  <SelectValue placeholder="Select model" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="google/gemini-2.5-flash">
-                    Gemini 2.5 Flash
-                  </SelectItem>
-                  <SelectItem value="openai/gpt-oss-120b">
-                    GPT-OSS-120B
-                  </SelectItem>
-                  <SelectItem value="x-ai/grok-4.1-fast">
-                    Grok 4.1 Fast
-                  </SelectItem>
-                  <SelectItem value="deepseek/deepseek-v3.2">
-                    DeepSeek V3.2
-                  </SelectItem>
-                  <SelectItem value="openai/gpt-5-mini">GPT-5 Mini</SelectItem>
-                  <SelectItem value="openai/gpt-4.1-nano">
-                    GPT-4.1 Nano
-                  </SelectItem>
-                  <SelectItem value="openai/gpt-4o-mini">
-                    GPT-4o Mini
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <Button
-              className="w-full"
-              onClick={handleStartBacktest}
-              disabled={creating || !formData.start_date || !formData.end_date}
-            >
-              {creating ? (
-                <>
-                  <motion.div
-                    className="w-4 h-4 mr-2 bg-current rounded-sm"
-                    animate={{ opacity: [0.4, 1, 0.4] }}
-                    transition={{ duration: 1, repeat: Infinity }}
-                  />
-                  Starting...
-                </>
-              ) : (
-                <>
-                  <Play className="w-4 h-4 mr-2" />
-                  Start Backtest
-                </>
-              )}
-            </Button>
-          </div>
-
-          {/* Previous Runs */}
-          <div className="p-4 border-t border-white/5">
-            <h3 className="font-medium mb-3">Previous Runs</h3>
-            <ScrollArea className="h-[200px]">
-              <div className="space-y-2">
-                {runs.length === 0 ? (
-                  <p className="text-sm text-muted-foreground text-center py-4">
-                    No backtests yet
-                  </p>
-                ) : (
-                  runs.map((run) => (
-                    <motion.div
-                      key={run.run_id}
-                      initial={{ opacity: 0, x: -10 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      className={`p-3 rounded-lg cursor-pointer transition-all ${
-                        selectedRun === run.run_id
-                          ? "bg-primary/20 border border-primary/30"
-                          : "bg-white/5 hover:bg-white/10"
-                      }`}
-                      onClick={() => setSelectedRun(run.run_id)}
-                    >
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-medium truncate">
-                          {run.config?.symbols?.join(", ") || "No symbols"}
-                        </span>
-                        <GlowBadge
-                          variant={
-                            run.status === "running"
-                              ? "info"
-                              : run.status === "completed"
-                              ? "success"
-                              : run.status === "failed"
-                              ? "danger"
-                              : "secondary"
-                          }
-                          pulse={run.status === "running"}
-                        >
-                          {run.status}
-                        </GlowBadge>
-                      </div>
-                      <div className="flex items-center justify-between text-xs text-muted-foreground">
-                        <span>
-                          ${(run.config?.initial_balance || 0).toLocaleString()}
-                        </span>
-                        <div className="flex gap-1">
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="h-6 w-6"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleDeleteBacktest(run.run_id);
-                            }}
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </Button>
-                        </div>
-                      </div>
-                      {run.error && (
-                        <div className="mt-2 text-xs text-red-400 truncate">
-                          {run.error}
-                        </div>
-                      )}
-                      {run.status === "running" && (
-                        <div className="mt-2">
-                          <ProgressStat
-                            label="Progress"
-                            value={run.progress}
-                            color="primary"
-                          />
-                        </div>
-                      )}
-                    </motion.div>
-                  ))
-                )}
-              </div>
-            </ScrollArea>
-          </div>
-        </GlassCard>
-
-        {/* Results Panel */}
-        <div className="lg:col-span-2 space-y-6">
-          {selectedRun && currentRun ? (
-            <>
-              {/* Metrics Cards */}
-              {metrics && (
-                <div className="grid gap-3 lg:gap-4 grid-cols-2 lg:grid-cols-4">
-                  <StatCard
-                    title="Total PnL"
-                    value={metrics.total_return}
-                    icon={metrics.total_return >= 0 ? TrendingUp : TrendingDown}
-                    prefix="$"
-                    decimals={2}
-                    colorize
-                    change={metrics.total_return_pct}
-                    delay={0}
-                  />
-                  <StatCard
-                    title="Win Rate"
-                    value={metrics.win_rate}
-                    icon={Target}
-                    suffix="%"
-                    decimals={1}
-                    delay={1}
-                  />
-                  <StatCard
-                    title="Total Trades"
-                    value={metrics.total_trades}
-                    icon={Activity}
-                    decimals={0}
-                    delay={2}
-                  />
-                  <StatCard
-                    title="Sharpe Ratio"
-                    value={metrics.sharpe_ratio}
-                    icon={Percent}
-                    decimals={2}
-                    delay={3}
-                  />
-                </div>
-              )}
-
-              {/* Charts */}
-              <GlassCard>
-                <Tabs defaultValue="equity">
-                  <TabsList className="grid grid-cols-3 w-full max-w-md">
-                    <TabsTrigger value="equity">Equity Curve</TabsTrigger>
-                    <TabsTrigger value="trades">Trades</TabsTrigger>
-                    <TabsTrigger value="metrics">Metrics</TabsTrigger>
-                  </TabsList>
-
-                  <TabsContent value="equity" className="mt-4">
-                    {equityCurve.length > 0 ? (
-                      <div className="h-[250px] lg:h-[350px]">
-                        <ResponsiveContainer width="100%" height="100%">
-                          <AreaChart data={equityCurve}>
-                            <defs>
-                              <linearGradient
-                                id="colorEquity"
-                                x1="0"
-                                y1="0"
-                                x2="0"
-                                y2="1"
-                              >
-                                <stop
-                                  offset="5%"
-                                  stopColor="#3b82f6"
-                                  stopOpacity={0.3}
-                                />
-                                <stop
-                                  offset="95%"
-                                  stopColor="#3b82f6"
-                                  stopOpacity={0}
-                                />
-                              </linearGradient>
-                            </defs>
-                            <CartesianGrid
-                              strokeDasharray="3 3"
-                              stroke="#ffffff10"
-                            />
-                            <XAxis
-                              dataKey="timestamp"
-                              stroke="#71717a"
-                              fontSize={12}
-                              tickFormatter={(v) =>
-                                new Date(v).toLocaleDateString()
-                              }
-                            />
-                            <YAxis
-                              stroke="#71717a"
-                              fontSize={12}
-                              tickFormatter={(v) => `$${v.toLocaleString()}`}
-                            />
-                            <Tooltip
-                              contentStyle={{
-                                backgroundColor: "#12121a",
-                                border: "1px solid rgba(255,255,255,0.1)",
-                                borderRadius: "8px",
-                              }}
-                              labelFormatter={(v) =>
-                                new Date(v).toLocaleString()
-                              }
-                              formatter={(v) => [
-                                `$${Number(v).toFixed(2)}`,
-                                "Equity",
-                              ]}
-                            />
-                            <Area
-                              type="monotone"
-                              dataKey="equity"
-                              stroke="#3b82f6"
-                              strokeWidth={2}
-                              fill="url(#colorEquity)"
-                            />
-                          </AreaChart>
-                        </ResponsiveContainer>
-                      </div>
-                    ) : (
-                      <div className="h-[200px] lg:h-[350px] flex items-center justify-center">
-                        <p className="text-muted-foreground">
-                          No equity data available
-                        </p>
-                      </div>
-                    )}
-                  </TabsContent>
-
-                  <TabsContent value="trades" className="mt-4">
-                    <ScrollArea className="h-[250px] lg:h-[350px]">
-                      <div className="p-4 lg:p-0">
-                        <MobileCardTable<Trade>
-                          data={trades}
-                          keyExtractor={(_, i) => i}
-                          columns={[
-                            {
-                              key: "symbol",
-                              label: "Symbol",
-                              primary: true,
-                              render: (v) => (
-                                <span className="font-medium">{v}</span>
-                              ),
-                            },
-                            {
-                              key: "side",
-                              label: "Side",
-                              primary: true,
-                              render: (v) => (
-                                <GlowBadge
-                                  variant={v === "LONG" ? "success" : "danger"}
-                                >
-                                  {v}
-                                </GlowBadge>
-                              ),
-                            },
-                            {
-                              key: "pnl",
-                              label: "PnL",
-                              primary: true,
-                              align: "right",
-                              render: (v, trade) => (
-                                <span
-                                  className={`font-mono font-medium ${
-                                    v > 0
-                                      ? "text-green-400"
-                                      : v < 0
-                                      ? "text-red-400"
-                                      : "text-muted-foreground"
-                                  }`}
-                                >
-                                  ${v.toFixed(2)} (
-                                  {trade.pnl_percent > 0 ? "+" : ""}
-                                  {trade.pnl_percent.toFixed(1)}%)
-                                </span>
-                              ),
-                            },
-                            {
-                              key: "timestamp",
-                              label: "Time",
-                              render: (v) => (
-                                <span className="text-sm">
-                                  {new Date(v).toLocaleDateString()}
-                                </span>
-                              ),
-                            },
-                            {
-                              key: "entry_price",
-                              label: "Entry",
-                              align: "right",
-                              render: (v) => (
-                                <span className="font-mono">
-                                  ${v.toFixed(2)}
-                                </span>
-                              ),
-                            },
-                            {
-                              key: "exit_price",
-                              label: "Exit",
-                              align: "right",
-                              render: (v) => (
-                                <span className="font-mono">
-                                  ${v.toFixed(2)}
-                                </span>
-                              ),
-                            },
-                          ]}
-                          emptyState={
-                            <div className="h-[200px] flex items-center justify-center">
-                              <p className="text-muted-foreground">
-                                No trades yet
-                              </p>
-                            </div>
-                          }
-                        />
-                      </div>
-                    </ScrollArea>
-                  </TabsContent>
-
-                  <TabsContent value="metrics" className="mt-4">
-                    {metrics ? (
-                      <div className="grid gap-4 md:grid-cols-2">
-                        <SpotlightCard className="p-4">
-                          <h4 className="text-sm text-muted-foreground mb-3">
-                            Trade Statistics
-                          </h4>
-                          <div className="space-y-3">
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Winning Trades
-                              </span>
-                              <span className="font-medium text-green-400">
-                                {metrics.winning_trades}
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Losing Trades
-                              </span>
-                              <span className="font-medium text-red-400">
-                                {metrics.losing_trades}
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Avg Win
-                              </span>
-                              <span className="font-medium text-green-400">
-                                ${metrics.avg_win.toFixed(2)}
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Avg Loss
-                              </span>
-                              <span className="font-medium text-red-400">
-                                ${Math.abs(metrics.avg_loss).toFixed(2)}
-                              </span>
-                            </div>
-                          </div>
-                        </SpotlightCard>
-
-                        <SpotlightCard className="p-4">
-                          <h4 className="text-sm text-muted-foreground mb-3">
-                            Risk Metrics
-                          </h4>
-                          <div className="space-y-3">
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Max Drawdown
-                              </span>
-                              <span className="font-medium text-red-400">
-                                {metrics.max_drawdown_pct.toFixed(2)}%
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Profit Factor
-                              </span>
-                              <span className="font-medium">
-                                {metrics.profit_factor.toFixed(2)}
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Sharpe Ratio
-                              </span>
-                              <span className="font-medium">
-                                {metrics.sharpe_ratio.toFixed(2)}
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">
-                                Win Rate
-                              </span>
-                              <span className="font-medium">
-                                {metrics.win_rate.toFixed(1)}%
-                              </span>
-                            </div>
-                          </div>
-                        </SpotlightCard>
-                      </div>
-                    ) : (
-                      <div className="h-[350px] flex items-center justify-center">
-                        <p className="text-muted-foreground">
-                          No metrics available
-                        </p>
-                      </div>
-                    )}
-                  </TabsContent>
-                </Tabs>
-              </GlassCard>
-            </>
-          ) : (
-            <GlassCard className="p-12 text-center">
-              <FlaskConical className="w-16 h-16 text-muted-foreground/30 mx-auto mb-4" />
-              <h3 className="text-xl font-medium mb-2">No Backtest Selected</h3>
-              <p className="text-muted-foreground">
-                Configure and start a new backtest, or select a previous run
-                from the list.
-              </p>
-            </GlassCard>
-          )}
+    <div className="page fade-in">
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Backtest</h1>
+          <p className="page-desc">Prove it on history before it touches capital</p>
+        </div>
+        <div className="row" style={{ gap: 8 }}>
+          <button className="btn icon" onClick={() => void loadData()} title="Refresh">
+            <Ic name="refresh" size={15} />
+          </button>
+          <button
+            className="btn primary"
+            onClick={() => void handleStartBacktest()}
+            disabled={!canRunBacktest}
+            title={runDisabledTitle}
+          >
+            <Ic name="play" size={14} />
+            {creating ? "Running…" : "Run backtest"}
+          </button>
         </div>
       </div>
 
-      {/* Confirmation and Alert Dialogs */}
+      {error && (
+        <div
+          className="panel panel-pad"
+          style={{
+            marginBottom: 16,
+            borderColor: "rgba(224,98,94,.4)",
+            color: "var(--down)",
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 286px", gap: 16, alignItems: "start" }}>
+        {/* ============ LEFT: results ============ */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          {/* Equity vs buy & hold + drawdown */}
+          <div className="panel panel-pad">
+            <div
+              className="row"
+              style={{ justifyContent: "space-between", alignItems: "flex-start", marginBottom: 16, flexWrap: "wrap", gap: 12 }}
+            >
+              <div>
+                <div className="serif" style={{ fontSize: 22, fontWeight: 600 }}>
+                  {currentRun?.name || cfg?.name || form.name || "Backtest"}
+                </div>
+                <div className="faint" style={{ fontSize: 12.5 }}>
+                  {cfg
+                    ? `${fmtRange(cfg)} · ${(cfg.symbols || []).map(displaySymbol).join(" · ")} · ${cfg.decision_timeframe || ""}`
+                    : "Configure a run, then prove it on history"}
+                </div>
+              </div>
+              {metrics && (
+                <div className="row" style={{ gap: 22 }}>
+                  <div style={{ textAlign: "right" }}>
+                    <div
+                      className="mono"
+                      style={{
+                        fontSize: 27,
+                        fontWeight: 700,
+                        color: metrics.total_return_pct >= 0 ? "var(--up)" : "var(--down)",
+                      }}
+                    >
+                      {sg(metrics.total_return_pct) + "%"}
+                    </div>
+                    <div className="eyebrow">strategy</div>
+                  </div>
+                  <div style={{ textAlign: "right" }}>
+                    <div className="mono" style={{ fontSize: 27, color: "var(--text)" }}>
+                      {m$(metrics.final_equity, 0)}
+                    </div>
+                    <div className="eyebrow">final equity</div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* legend */}
+            <div className="row" style={{ gap: 18, marginBottom: 12 }}>
+              <span className="row" style={{ gap: 6, fontSize: 12 }}>
+                <span style={{ width: 16, height: 2, background: "var(--accent)", display: "inline-block" }} />
+                Equity
+              </span>
+              <span className="row" style={{ gap: 6, fontSize: 12, color: "var(--text-3)" }}>
+                <span style={{ width: 16, borderTop: "1px dashed var(--line-strong)", display: "inline-block" }} />
+                {minDrawdown < 0 ? `peak-to-trough ${minDrawdown.toFixed(1)}%` : "drawdown below"}
+              </span>
+            </div>
+
+            {hasResults ? (
+              <>
+                <AreaPlus
+                  data={equitySeries}
+                  height={228}
+                  color="var(--accent)"
+                  fmt={(v) => m$(v)}
+                  labelFor={(i) =>
+                    equityCurve[i] ? new Date(equityCurve[i].timestamp).toLocaleDateString() : ""
+                  }
+                />
+                <div className="eyebrow" style={{ margin: "16px 0 6px" }}>
+                  Drawdown
+                </div>
+                <Underwater data={drawdownSeries} height={62} />
+              </>
+            ) : (
+              <div
+                style={{
+                  height: 300,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 10,
+                  color: "var(--text-3)",
+                  border: "1px dashed var(--line)",
+                  borderRadius: "var(--r)",
+                }}
+              >
+                <Ic name="backtest" size={26} />
+                <div style={{ fontSize: 13 }}>
+                  {currentRun?.status === "running"
+                    ? "Backtest running… results will appear as it completes"
+                    : "No results yet — run a backtest or pick a previous run"}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* metric tiles */}
+          {metrics ? (
+            <div className="grid-4">
+              {tiles.map((c, i) => (
+                <div key={i} className="stat">
+                  <span className="label">{c[0]}</span>
+                  <div className="value" style={{ fontSize: 20, color: c[2] }}>
+                    {c[1]}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="grid-4">
+              {["Net return", "Sharpe", "Sortino", "Max drawdown", "Win rate", "Profit factor", "Trades", "Avg R:R", "Expectancy", "Avg hold"].map(
+                (label, i) => (
+                  <div key={i} className="stat">
+                    <span className="label">{label}</span>
+                    <div className="value" style={{ fontSize: 20, color: "var(--text-3)" }}>
+                      &mdash;
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+          )}
+
+          {/* monthly + distribution */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+            <div className="panel" style={{ overflow: "hidden" }}>
+              <div className="panel-head">
+                <h3>
+                  <Ic name="ranking" />
+                  Monthly returns
+                </h3>
+              </div>
+              <div className="panel-pad">
+                {monthly.length ? (
+                  <MonthlyBars data={monthly} />
+                ) : (
+                  <div className="faint" style={{ fontSize: 12.5, padding: "18px 0", textAlign: "center" }}>
+                    No monthly data yet
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="panel" style={{ overflow: "hidden" }}>
+              <div className="panel-head">
+                <h3>
+                  <Ic name="backtest" />
+                  Trade distribution
+                </h3>
+                <span className="sub">{closedCount} trades</span>
+              </div>
+              <div className="panel-pad">
+                {tradeReturns.length ? (
+                  <ReturnHistogram data={tradeReturns} />
+                ) : (
+                  <div className="faint" style={{ fontSize: 12.5, padding: "18px 0", textAlign: "center" }}>
+                    No closed trades yet
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* previous runs */}
+          <div className="panel" style={{ overflow: "hidden" }}>
+            <div className="panel-head">
+              <h3>
+                <Ic name="history" />
+                Previous runs
+              </h3>
+              <span className="sub">{runs.length} total</span>
+            </div>
+            {runs.length === 0 ? (
+              <div className="panel-pad faint" style={{ fontSize: 13, textAlign: "center" }}>
+                No backtests yet
+              </div>
+            ) : (
+              <div>
+                {runs.map((run, i) => {
+                  const active = selectedRun === run.run_id;
+                  const runSymbols = run.config?.symbols || [];
+                  const runInterval = run.config?.decision_timeframe || "1h";
+                  const statusColor =
+                    run.status === "completed"
+                      ? "var(--up)"
+                      : run.status === "running"
+                      ? "var(--warn)"
+                      : run.status === "failed"
+                      ? "var(--down)"
+                      : "var(--text-3)";
+                  return (
+                    <div
+                      key={run.run_id}
+                      onClick={() => setSelectedRun(run.run_id)}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 14,
+                        padding: "12px 18px",
+                        borderBottom: i < runs.length - 1 ? "1px solid var(--line)" : "none",
+                        cursor: "pointer",
+                        background: active ? "var(--surface-2)" : "transparent",
+                        borderLeft: active ? "2px solid var(--accent)" : "2px solid transparent",
+                      }}
+                    >
+                      <span
+                        className="badge"
+                        style={{ color: statusColor, borderColor: "var(--line-2)", flex: "none" }}
+                      >
+                        {run.status === "running" && (
+                          <span className="dot live" style={{ width: 5, height: 5 }} />
+                        )}
+                        {run.status}
+                      </span>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div className="sym mono row" style={{ gap: 4, fontWeight: 600, fontSize: 13, flexWrap: "wrap" }}>
+                          {runSymbols.length > 0
+                            ? runSymbols.map((sym, idx) => (
+                                <span key={sym} className="row" style={{ gap: 4 }}>
+                                  {idx > 0 && <span>,</span>}
+                                  <button
+                                    type="button"
+                                    className="sym mono"
+                                    title={`Open ${displaySymbol(sym)} chart`}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      navigate(chartLink(sym, runInterval));
+                                    }}
+                                    style={{
+                                      background: "transparent",
+                                      border: 0,
+                                      padding: 0,
+                                      color: "inherit",
+                                      cursor: "pointer",
+                                      font: "inherit",
+                                      fontWeight: 600,
+                                    }}
+                                  >
+                                    {displaySymbol(sym)}
+                                  </button>
+                                </span>
+                              ))
+                            : run.name || "Backtest"}
+                        </div>
+                        <div className="faint" style={{ fontSize: 11 }}>
+                          {fmtRange(run.config)}
+                          {run.error ? ` · ${run.error}` : ""}
+                        </div>
+                      </div>
+                      <span className="mono faint" style={{ fontSize: 12 }}>
+                        {m$(run.config?.initial_balance ?? 0, 0)}
+                      </span>
+                      {typeof run.progress === "number" && run.status === "running" && (
+                        <div className="meter" style={{ width: 70 }}>
+                          <span style={{ width: `${Math.round((run.progress || 0) * 100)}%` }} />
+                        </div>
+                      )}
+                      {run.status === "running" && (
+                        <button
+                          className="btn ghost icon"
+                          title="Stop run"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleStopBacktest(run.run_id);
+                          }}
+                        >
+                          <Ic name="stop" size={14} />
+                        </button>
+                      )}
+                      <button
+                        className="btn ghost icon"
+                        title="Delete run"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleDeleteBacktest(run.run_id);
+                        }}
+                      >
+                        <Ic name="x" size={14} />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* ============ RIGHT: run configuration ============ */}
+        <div className="panel" style={{ overflow: "hidden", position: "sticky", top: 76 }}>
+          <div className="panel-head">
+            <h3>
+                <Ic name="config" />
+                Run configuration
+              </h3>
+            </div>
+          <div className="panel-pad" style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+            {setupSource && (
+              <div
+                className="row"
+                style={{
+                  alignItems: "flex-start",
+                  gap: 9,
+                  padding: "10px 12px",
+                  borderRadius: "var(--r)",
+                  border: "1px solid var(--accent-line)",
+                  background: "var(--accent-dim)",
+                  color: "var(--text-2)",
+                  fontSize: 12,
+                  lineHeight: 1.45,
+                }}
+              >
+                <Ic name="chart" size={15} style={{ color: "var(--accent)", flex: "none", marginTop: 1 }} />
+                <span>
+                  <strong style={{ color: "var(--text)" }}>{setupSource}</strong>
+                  {" "}This only pre-fills the backtest form; it does not start a run.
+                </span>
+              </div>
+            )}
+
+            {/* Strategy name */}
+            <div>
+              <div className="eyebrow" style={{ marginBottom: 5 }}>
+                Strategy name
+              </div>
+              <input
+                style={inputStyle}
+                value={form.name}
+                onChange={(e) => set("name", e.target.value)}
+                placeholder="Conservative Trend"
+              />
+            </div>
+
+            {/* Symbols */}
+            <div>
+              <div className="eyebrow" style={{ marginBottom: 5 }}>
+                Symbols
+              </div>
+              <input
+                style={inputStyle}
+                value={form.symbols}
+                onChange={(e) => set("symbols", e.target.value)}
+                placeholder="BTCUSDT, ETHUSDT, SOLUSDT"
+              />
+            </div>
+
+            {/* Date range */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  Start
+                </div>
+                <input
+                  type="date"
+                  style={inputStyle}
+                  value={form.start_date}
+                  onChange={(e) => set("start_date", e.target.value)}
+                />
+              </div>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  End
+                </div>
+                <input
+                  type="date"
+                  style={inputStyle}
+                  value={form.end_date}
+                  onChange={(e) => set("end_date", e.target.value)}
+                />
+              </div>
+            </div>
+
+            {/* Timeframe + capital */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  Timeframe
+                </div>
+                <select
+                  style={inputStyle}
+                  value={form.timeframe}
+                  onChange={(e) => set("timeframe", e.target.value)}
+                >
+                  {BACKTEST_TIMEFRAMES.map((tf) => (
+                    <option key={tf} value={tf}>
+                      {tf}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  Capital ($)
+                </div>
+                <input
+                  type="number"
+                  style={inputStyle}
+                  value={form.initial_capital}
+                  onChange={(e) => set("initial_capital", Number(e.target.value))}
+                />
+              </div>
+            </div>
+
+            {/* Leverage */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  BTC/ETH lev
+                </div>
+                <input
+                  type="number"
+                  style={inputStyle}
+                  value={form.btc_eth_leverage}
+                  onChange={(e) => set("btc_eth_leverage", Number(e.target.value))}
+                />
+              </div>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  Altcoin lev
+                </div>
+                <input
+                  type="number"
+                  style={inputStyle}
+                  value={form.altcoin_leverage}
+                  onChange={(e) => set("altcoin_leverage", Number(e.target.value))}
+                />
+              </div>
+            </div>
+
+            {/* Fees + slippage (basis points) */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  Taker fee (bps)
+                </div>
+                <input
+                  type="number"
+                  style={inputStyle}
+                  value={form.fee_bps}
+                  onChange={(e) => set("fee_bps", Number(e.target.value))}
+                />
+              </div>
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  Slippage (bps)
+                </div>
+                <input
+                  type="number"
+                  style={inputStyle}
+                  value={form.slippage_bps}
+                  onChange={(e) => set("slippage_bps", Number(e.target.value))}
+                />
+              </div>
+            </div>
+
+            {/* Strategy preset */}
+            {strategies.length > 0 && (
+              <div>
+                <div className="eyebrow" style={{ marginBottom: 5 }}>
+                  Strategy preset{" "}
+                  <span className="faint" style={{ textTransform: "none" }}>· not applied yet</span>
+                </div>
+                <select
+                  style={inputStyle}
+                  value={form.strategy_id}
+                  onChange={(e) => set("strategy_id", e.target.value)}
+                >
+                  <option value="">None</option>
+                  {strategies.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* AI model — live concierge sync */}
+            <div>
+              <div className="eyebrow" style={{ marginBottom: 5 }}>
+                AI model{" "}
+                <span className="faint" style={{ textTransform: "none" }}>· not applied yet</span>
+              </div>
+              <select
+                style={inputStyle}
+                value={form.ai_model}
+                onChange={(e) => set("ai_model", e.target.value)}
+                onFocus={() => refreshModels()}
+                disabled={modelOptions.length === 0}
+              >
+                {modelOptions.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <button
+              className="btn primary"
+              style={{ justifyContent: "center", marginTop: 4 }}
+              onClick={() => void handleStartBacktest()}
+              disabled={!canRunBacktest}
+              title={runDisabledTitle}
+            >
+              <Ic name="play" size={14} />
+              {creating ? "Running…" : "Run backtest"}
+            </button>
+
+            {/* Echo of the active run's resolved configuration. */}
+            <div style={{ borderTop: "1px solid var(--line)", margin: "4px 0 0", paddingTop: 12, display: "flex", flexDirection: "column", gap: 9 }}>
+              <div className="eyebrow">Active run</div>
+              {configRows.map((c, i) => (
+                <div key={i} className="row" style={{ justifyContent: "space-between", gap: 12 }}>
+                  <span className="faint" style={{ fontSize: 11.5 }}>
+                    {c[0]}
+                  </span>
+                  <span className="mono" style={{ fontSize: 11.5, textAlign: "right", color: "var(--text-2)" }}>
+                    {c[1]}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
       {ConfirmDialog}
       {AlertDialog}
     </div>

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -6,12 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"auto-trader-ahh/analysis"
 	"auto-trader-ahh/backtest"
 	"auto-trader-ahh/config"
 	"auto-trader-ahh/debate"
@@ -27,21 +30,23 @@ import (
 )
 
 type Server struct {
-	port            string
-	strategyStore   *store.StrategyStore
-	traderStore     *store.TraderStore
-	decisionStore   *store.DecisionStore
-	equityStore     *store.EquityStore
-	tradeStore      *store.TradeStore
-	settingsStore   *store.SettingsStore
-	engineManager   *trader.EngineManager
-	debateEngine    *debate.Engine
-	backtestManager *backtest.Manager
-	aiClient        mcp.AIClient
-	binanceClient   *exchange.BinanceClient
-	accessPasskey   string
-	cfg             *config.Config
-	hub             *events.Hub
+	port             string
+	strategyStore    *store.StrategyStore
+	traderStore      *store.TraderStore
+	positionStore    *store.PositionStore
+	decisionStore    *store.DecisionStore
+	equityStore      *store.EquityStore
+	tradeStore       *store.TradeStore
+	settingsStore    *store.SettingsStore
+	attributionStore *store.AttributionStore
+	engineManager    *trader.EngineManager
+	debateEngine     *debate.Engine
+	backtestManager  *backtest.Manager
+	aiClient         mcp.AIClient
+	binanceClient    exchange.Exchange
+	accessPasskey    string
+	cfg              *config.Config
+	hub              *events.Hub
 
 	// SECURITY: Rate limiting
 	rateLimiters map[string]*rate.Limiter
@@ -49,11 +54,14 @@ type Server struct {
 }
 
 func NewServer(port string, em *trader.EngineManager, cfg *config.Config) *Server {
-	// Create OpenRouter AI client
-	aiClient := mcp.NewOpenRouterClient(cfg.OpenRouterAPIKey, cfg.OpenRouterModel)
+	// AI client — routed through the local Quota Concierge sidecar (Claude MAX / Codex)
+	aiClient := mcp.NewConciergeClient(cfg.LLMModel)
 
-	// Create Binance client for backtest
-	binanceClient := exchange.NewBinanceClient(cfg.BinanceAPIKey, cfg.BinanceSecretKey, cfg.BinanceTestnet)
+	// Exchange client for backtest + dashboard market endpoints (active venue from EXCHANGE)
+	binanceClient, exErr := exchange.NewExchange(cfg)
+	if exErr != nil {
+		log.Fatalf("exchange init failed: %v", exErr)
+	}
 
 	// Create debate engine and register AI client
 	debateEng := debate.NewEngine()
@@ -65,27 +73,32 @@ func NewServer(port string, em *trader.EngineManager, cfg *config.Config) *Serve
 	equityStore := store.NewEquityStore()
 
 	srv := &Server{
-		port:            port,
-		strategyStore:   store.NewStrategyStore(),
-		traderStore:     store.NewTraderStore(),
-		decisionStore:   store.NewDecisionStore(),
-		equityStore:     equityStore,
-		tradeStore:      store.NewTradeStore(),
-		settingsStore:   store.NewSettingsStore(),
-		engineManager:   em,
-		debateEngine:    debateEng,
-		backtestManager: backtest.NewManager(aiClient, binanceClient),
-		aiClient:        aiClient,
-		binanceClient:   binanceClient,
-		accessPasskey:   cfg.AccessPasskey,
-		cfg:             cfg,
-		hub:             em.GetHub(),
-		rateLimiters:    make(map[string]*rate.Limiter),
+		port:             port,
+		strategyStore:    store.NewStrategyStore(),
+		traderStore:      store.NewTraderStore(),
+		positionStore:    store.NewPositionStore(),
+		decisionStore:    store.NewDecisionStore(),
+		equityStore:      equityStore,
+		tradeStore:       store.NewTradeStore(),
+		settingsStore:    store.NewSettingsStore(),
+		attributionStore: store.NewAttributionStore(),
+		engineManager:    em,
+		debateEngine:     debateEng,
+		backtestManager:  backtest.NewManager(aiClient, binanceClient),
+		aiClient:         aiClient,
+		binanceClient:    binanceClient,
+		accessPasskey:    cfg.AccessPasskey,
+		cfg:              cfg,
+		hub:              em.GetHub(),
+		rateLimiters:     make(map[string]*rate.Limiter),
 	}
 
 	// Wire up debate engine with market context provider and trade executor
 	debateEng.SetMarketContextProvider(srv.buildDebateMarketContextForCycle)
 	debateEng.SetTradeExecutor(srv.executeDebateDecisions)
+	// Council Attribution v0: log every consensus into attribution with participant
+	// persona/model provenance (read-only; fires for auto-execute and read-only sessions).
+	debateEng.SetConsensusRecorder(srv.recordCouncilConsensus)
 
 	return srv
 }
@@ -111,12 +124,53 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/traders/", s.authMiddleware(s.handleTrader))
 
 	// Data endpoints
+	mux.HandleFunc("/api/symbols", s.authMiddleware(s.handleSymbols))
+	mux.HandleFunc("/api/top-watches", s.authMiddleware(s.handleTopWatches))
+	mux.HandleFunc("/api/klines", s.authMiddleware(s.handleKlines))
+	mux.HandleFunc("/api/patterns", s.authMiddleware(s.handlePatterns))
+	// Live AI trading assistant (reliable non-streaming + token-streaming SSE)
+	mux.HandleFunc("/api/assistant/analyze", s.authMiddleware(s.handleAssistantAnalyze))
+	mux.HandleFunc("/api/assistant/stream", s.authMiddleware(s.handleAssistantStream))
+	// AI decision engine: one verdict per symbol + a management verdict per open position
+	mux.HandleFunc("/api/verdict", s.authMiddleware(s.handleVerdict))
+	mux.HandleFunc("/api/guardian", s.authMiddleware(s.handleGuardian))
+	// Deterministic signal board (fast, no LLM) — the "what the system is seeing" layer
+	mux.HandleFunc("/api/signals", s.authMiddleware(s.handleSignals))
+	// Read-only Validation Harness v0 — replays the deterministic board over history
+	mux.HandleFunc("/api/validation/signals", s.authMiddleware(s.handleValidationSignals))
+	// Read-only Attribution Log v0 — the Feedback Loop's evidence floor. Every fresh
+	// verdict is logged with the board it weighed; these endpoints inspect that log.
+	mux.HandleFunc("/api/attribution/verdicts", s.authMiddleware(s.handleAttributionVerdicts))
+	mux.HandleFunc("/api/attribution/verdicts/", s.authMiddleware(s.handleAttributionVerdict))
+	mux.HandleFunc("/api/attribution/summary", s.authMiddleware(s.handleAttributionSummary))
+	// Outcome Linkage v0 — manual, local-only resolver: replays klines after each pending
+	// verdict to populate attribution_outcomes (passive; no trade/exchange writes).
+	mux.HandleFunc("/api/attribution/resolve-outcomes", s.authMiddleware(s.handleResolveOutcomes))
+	// Per-Signal Outcome Rollups v0 — read-only, stance-aware aggregation of resolved
+	// outcomes (evidence before knobs; no weight tuning).
+	mux.HandleFunc("/api/attribution/rollups", s.authMiddleware(s.handleAttributionRollups))
+	// Realized Trade Rollups v0 — read-only aggregation of explicitly linked action
+	// results, kept separate from passive market outcomes.
+	mux.HandleFunc("/api/attribution/realized-rollups", s.authMiddleware(s.handleAttributionRealizedRollups))
+	// Trade-Fill Linkage v0 — bridge verdicts↔real/paper trades. Read-only candidate
+	// detection + explicit local linkage; never places/cancels/modifies orders.
+	mux.HandleFunc("/api/attribution/trade-links", s.authMiddleware(s.handleTradeLinks))
+	mux.HandleFunc("/api/attribution/trade-links/candidates", s.authMiddleware(s.handleTradeLinkCandidates))
+	mux.HandleFunc("/api/attribution/link-trades", s.authMiddleware(s.handleLinkTrades))
 	mux.HandleFunc("/api/status", s.authMiddleware(s.handleStatus))
 	mux.HandleFunc("/api/account", s.authMiddleware(s.handleAccount))
 	mux.HandleFunc("/api/positions", s.authMiddleware(s.handlePositions))
 	mux.HandleFunc("/api/decisions", s.authMiddleware(s.handleDecisions))
 	mux.HandleFunc("/api/trades", s.authMiddleware(s.handleTrades))
+	mux.HandleFunc("/api/trades/", s.authMiddleware(s.handleTradeNarrative))
 	mux.HandleFunc("/api/equity-history", s.authMiddleware(s.handleEquityHistory))
+	mux.HandleFunc("/api/kill-switch", s.authMiddleware(s.handleKillSwitch))
+	mux.HandleFunc("/api/venue-config", s.authMiddleware(s.handleVenueConfig))
+	// Named venue connection profiles (save several Phemex connections; switch via dropdown).
+	mux.HandleFunc("/api/connections", s.authMiddleware(s.handleConnections))
+	mux.HandleFunc("/api/connections/activate", s.authMiddleware(s.handleConnectionActivate))
+	mux.HandleFunc("/api/connections/delete", s.authMiddleware(s.handleConnectionDelete))
+	mux.HandleFunc("/api/connections/balance", s.authMiddleware(s.handleConnectionBalance))
 
 	// Backtest endpoints
 	mux.HandleFunc("/api/backtest", s.authMiddleware(s.handleBacktests))
@@ -129,6 +183,7 @@ func (s *Server) Start() error {
 
 	// Settings endpoints
 	mux.HandleFunc("/api/settings", s.authMiddleware(s.handleSettings))
+	mux.HandleFunc("/api/favorites", s.authMiddleware(s.handleFavorites))
 
 	// System endpoints
 	mux.HandleFunc("/api/logs/stream", s.authMiddleware(s.handleLogStream))
@@ -137,7 +192,7 @@ func (s *Server) Start() error {
 	handler := s.rateLimitHandler(s.corsMiddleware(mux))
 
 	log.Printf("API server starting at http://localhost:%s", s.port)
-	log.Printf("SECURITY: Rate limiting enabled - 10 req/s per IP, burst 20")
+	log.Printf("SECURITY: Rate limiting enabled - 50 req/s per IP, burst 100 (loopback exempt)")
 	if s.accessPasskey != "" {
 		log.Printf("Authentication enabled - passkey required")
 	} else {
@@ -155,8 +210,10 @@ func (s *Server) getLimiter(ip string) *rate.Limiter {
 
 	limiter, exists := s.rateLimiters[ip]
 	if !exists {
-		// Create new limiter: 10 requests per second with burst of 20
-		limiter = rate.NewLimiter(rate.Limit(10), 20)
+		// Create new limiter: 50 req/s, burst 100. Loopback (the local UI) is exempted
+		// entirely in the middleware, so this cap only applies to non-local clients, which
+		// must also pass the passkey auth gate.
+		limiter = rate.NewLimiter(rate.Limit(50), 100)
 		s.rateLimiters[ip] = limiter
 
 		// Clean up old limiters periodically (every 100 new IPs)
@@ -181,9 +238,28 @@ func (s *Server) cleanupLimiters() {
 	}
 }
 
+// isLoopbackAddr reports whether a request originates from localhost (the local UI / sidecar).
+// Loopback is exempt from rate limiting: the dashboard polls many endpoints at once, and the
+// passkey (authMiddleware) is the real access gate.
+func isLoopbackAddr(remoteAddr string) bool {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return host == "localhost"
+}
+
 // rateLimitMiddleware enforces rate limits per IP address (for http.HandlerFunc)
 func (s *Server) rateLimitMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Local UI / sidecar traffic is never rate-limited (auth gates it instead).
+		if isLoopbackAddr(r.RemoteAddr) {
+			next(w, r)
+			return
+		}
 		// Extract IP from request
 		ip := r.RemoteAddr
 		if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
@@ -209,6 +285,10 @@ func (s *Server) rateLimitMiddleware(next http.HandlerFunc) http.HandlerFunc {
 // rateLimitHandler wraps an http.Handler with rate limiting
 func (s *Server) rateLimitHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isLoopbackAddr(r.RemoteAddr) {
+			next.ServeHTTP(w, r)
+			return
+		}
 		// Extract IP from request
 		ip := r.RemoteAddr
 		if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
@@ -740,6 +820,9 @@ func (s *Server) handleTrader(w http.ResponseWriter, r *http.Request) {
 			}
 			s.jsonResponse(w, map[string]string{"status": "resumed"})
 
+		case "execute":
+			s.handleExecuteTraderPlan(w, r, id)
+
 		default:
 			s.errorResponse(w, http.StatusBadRequest, "Unknown action")
 		}
@@ -796,6 +879,197 @@ func (s *Server) handleTrader(w http.ResponseWriter, r *http.Request) {
 
 // ============ DATA ENDPOINTS ============
 
+// handleSymbols returns all active futures for the active exchange, enriched
+// with last price and 24h percent change where a ticker is available. Only the
+// active venue is queried (no Binance hardcoding) — on Phemex the 24h ticker may
+// only cover majors, so symbols without ticker data report zeros.
+func (s *Server) handleSymbols(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		s.errorResponse(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Index 24h tickers by symbol for O(1) lookup of last price + percent change.
+	tickerBySymbol := make(map[string]exchange.Ticker24h)
+	if tickers, err := s.binanceClient.Get24hTicker(ctx); err != nil {
+		// Non-fatal: still return symbol metadata with zeroed price fields.
+		log.Printf("[Symbols] Failed to fetch 24h ticker: %v", err)
+	} else {
+		for _, t := range tickers {
+			tickerBySymbol[t.Symbol] = t
+		}
+	}
+
+	type symbolResponse struct {
+		Symbol            string  `json:"symbol"`
+		LastPrice         float64 `json:"lastPrice"`
+		PriceChangePct    float64 `json:"priceChangePct"`
+		MaxLeverage       int     `json:"maxLeverage"`
+		QuantityPrecision int     `json:"quantityPrecision"`
+		PricePrecision    int     `json:"pricePrecision"`
+	}
+
+	var result []symbolResponse
+	for _, info := range s.binanceClient.ListSymbols() {
+		// Filter to active contracts only (Binance: "TRADING", Phemex: "Listed").
+		if !strings.EqualFold(info.Status, "TRADING") && !strings.EqualFold(info.Status, "Listed") {
+			continue
+		}
+
+		item := symbolResponse{
+			Symbol:            info.Symbol,
+			MaxLeverage:       info.MaxLeverage,
+			QuantityPrecision: info.QuantityPrecision,
+			PricePrecision:    info.PricePrecision,
+		}
+		if t, ok := tickerBySymbol[info.Symbol]; ok {
+			item.LastPrice = t.LastPrice
+			item.PriceChangePct = t.PriceChange
+		}
+		result = append(result, item)
+	}
+
+	// Sort by symbol for a stable, predictable response order.
+	sort.Slice(result, func(i, j int) bool { return result[i].Symbol < result[j].Symbol })
+
+	s.jsonResponse(w, result)
+}
+
+// handleKlines returns OHLCV candles for a symbol from the active exchange,
+// shaped for lightweight-charts: oldest-first, with time in UNIX SECONDS.
+// Query params: symbol (required), interval (default "1h"), limit (default 300,
+// clamped to 1..1000). GetKlines already returns candles sorted ascending.
+func (s *Server) handleKlines(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		s.errorResponse(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	symbol := r.URL.Query().Get("symbol")
+	if symbol == "" {
+		s.errorResponse(w, http.StatusBadRequest, "symbol required")
+		return
+	}
+
+	interval := r.URL.Query().Get("interval")
+	if interval == "" {
+		interval = "1h"
+	}
+
+	limit := 300
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			limit = parsed
+		}
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	klines, err := s.binanceClient.GetKlines(ctx, symbol, interval, limit)
+	if err != nil {
+		s.errorResponse(w, http.StatusBadGateway, "Failed to fetch klines: "+err.Error())
+		return
+	}
+
+	type candle struct {
+		Time   int64   `json:"time"` // unix SECONDS (lightweight-charts)
+		Open   float64 `json:"open"`
+		High   float64 `json:"high"`
+		Low    float64 `json:"low"`
+		Close  float64 `json:"close"`
+		Volume float64 `json:"volume"`
+	}
+
+	// GetKlines returns ascending (oldest-first) — preserve that order.
+	result := make([]candle, 0, len(klines))
+	for _, k := range klines {
+		result = append(result, candle{
+			Time:   k.OpenTime / 1000, // ms -> seconds
+			Open:   k.Open,
+			High:   k.High,
+			Low:    k.Low,
+			Close:  k.Close,
+			Volume: k.Volume,
+		})
+	}
+
+	s.jsonResponse(w, result)
+}
+
+// handlePatterns runs deterministic, pure-Go chart-pattern detection over recent
+// klines from the active exchange and returns the detected patterns as a JSON
+// array (sorted by confidence desc; empty array when none found). The chart
+// overlay consumes this now; the live AI assistant will consume it later.
+// Query params: symbol (required), interval (default "1h"), limit (default 300,
+// clamped to 1..1000). Candle.Time carries OpenTime in UNIX MILLISECONDS.
+func (s *Server) handlePatterns(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		s.errorResponse(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	symbol := r.URL.Query().Get("symbol")
+	if symbol == "" {
+		s.errorResponse(w, http.StatusBadRequest, "symbol required")
+		return
+	}
+
+	interval := r.URL.Query().Get("interval")
+	if interval == "" {
+		interval = "1h"
+	}
+
+	limit := 300
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			limit = parsed
+		}
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	klines, err := s.binanceClient.GetKlines(ctx, symbol, interval, limit)
+	if err != nil {
+		s.errorResponse(w, http.StatusBadGateway, "Failed to fetch klines: "+err.Error())
+		return
+	}
+
+	// Map exchange klines onto the dependency-free analysis input. OpenTime is in
+	// UNIX MILLISECONDS and stays in ms in Candle.Time (the detectors never do
+	// time arithmetic; Time is carried through for context only).
+	candles := make([]analysis.Candle, 0, len(klines))
+	for _, k := range klines {
+		candles = append(candles, analysis.Candle{
+			Time:   k.OpenTime,
+			Open:   k.Open,
+			High:   k.High,
+			Low:    k.Low,
+			Close:  k.Close,
+			Volume: k.Volume,
+		})
+	}
+
+	patterns := analysis.DetectPatterns(candles)
+	s.jsonResponse(w, patterns)
+}
+
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	traderID := r.URL.Query().Get("trader_id")
 	if traderID == "" {
@@ -805,6 +1079,43 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	status := s.engineManager.GetStatus(traderID)
 	s.jsonResponse(w, status)
+}
+
+// handleKillSwitch reads or toggles the global order-placement kill switch.
+// GET  -> current {engaged, reason}. POST {engaged, reason} -> sets it and
+// returns the new state. When engaged, every order-write method on every venue
+// (paper, Phemex, Binance) returns exchange.ErrKillSwitch.
+func (s *Server) handleKillSwitch(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		s.jsonResponse(w, map[string]interface{}{
+			"engaged": exchange.KillSwitchEngaged(),
+			"reason":  exchange.KillSwitchReason(),
+		})
+
+	case "POST":
+		var req struct {
+			Engaged bool   `json:"engaged"`
+			Reason  string `json:"reason"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.errorResponse(w, http.StatusBadRequest, "Invalid request body")
+			return
+		}
+		exchange.SetKillSwitch(req.Engaged, req.Reason)
+		if req.Engaged {
+			log.Printf("[KillSwitch] ENGAGED - all order placement blocked (reason: %q)", req.Reason)
+		} else {
+			log.Printf("[KillSwitch] DISENGAGED - order placement resumed (reason: %q)", req.Reason)
+		}
+		s.jsonResponse(w, map[string]interface{}{
+			"engaged": exchange.KillSwitchEngaged(),
+			"reason":  exchange.KillSwitchReason(),
+		})
+
+	default:
+		s.errorResponse(w, http.StatusMethodNotAllowed, "Method not allowed")
+	}
 }
 
 func (s *Server) handleAccount(w http.ResponseWriter, r *http.Request) {
@@ -826,7 +1137,36 @@ func (s *Server) handlePositions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	positions := s.engineManager.GetPositions(traderID)
-	s.jsonResponse(w, map[string]interface{}{"positions": positions})
+	source := "engine"
+	// Fallback: when the live engine reports no positions (trader stopped, just
+	// restarted before the boot reconcile, or a transient reconcile that emptied
+	// the in-memory map), the dashboard would show nothing even though open
+	// positions are persisted in the DB. Surface the DB's open positions so the
+	// UI never silently hides a real open position.
+	if len(positions) == 0 {
+		if dbPos, err := s.positionStore.GetOpenPositions(traderID); err == nil && len(dbPos) > 0 {
+			positions = make([]map[string]interface{}, 0, len(dbPos))
+			for _, p := range dbPos {
+				amt := p.Quantity
+				if strings.EqualFold(p.Side, "short") {
+					amt = -amt
+				}
+				positions = append(positions, map[string]interface{}{
+					"symbol":      p.Symbol,
+					"side":        strings.ToUpper(p.Side),
+					"amount":      amt,
+					"entry_price": p.EntryPrice,
+					"mark_price":  p.EntryPrice, // no live mark when sourced from DB
+					"pnl":         0.0,
+					"pnl_percent": 0.0,
+					"leverage":    p.Leverage,
+					"source":      "db",
+				})
+			}
+			source = "db"
+		}
+	}
+	s.jsonResponse(w, map[string]interface{}{"positions": positions, "source": source})
 }
 
 func (s *Server) handleDecisions(w http.ResponseWriter, r *http.Request) {
@@ -868,6 +1208,26 @@ func (s *Server) handleTrades(w http.ResponseWriter, r *http.Request) {
 	traderID := r.URL.Query().Get("trader_id")
 	if traderID == "" {
 		s.errorResponse(w, http.StatusBadRequest, "trader_id required")
+		return
+	}
+
+	// "all" → aggregate across every trader, including ones whose trader/strategy row
+	// was later deleted (trades are never cascade-deleted). Powers the all-time view and
+	// keeps orphaned history visible. Read-only; no order activity.
+	if traderID == "all" {
+		trades, err := s.tradeStore.GetAll(5000)
+		if err != nil {
+			s.errorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		stats, err := s.tradeStore.GetAllStats()
+		if err != nil {
+			stats = map[string]interface{}{}
+		}
+		s.jsonResponse(w, map[string]interface{}{
+			"trades": trades,
+			"stats":  stats,
+		})
 		return
 	}
 
@@ -1093,6 +1453,13 @@ func (s *Server) handleDebateSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch action {
+	case "events":
+		if r.Method != "GET" {
+			s.errorResponse(w, http.StatusMethodNotAllowed, "Method not allowed")
+			return
+		}
+		s.handleDebateEvents(w, r, sessionID)
+
 	case "start":
 		if r.Method != "POST" {
 			s.errorResponse(w, http.StatusMethodNotAllowed, "Method not allowed")
@@ -1148,6 +1515,79 @@ func (s *Server) handleDebateSession(w http.ResponseWriter, r *http.Request) {
 
 	default:
 		s.errorResponse(w, http.StatusBadRequest, "Unknown action")
+	}
+}
+
+func (s *Server) handleDebateEvents(w http.ResponseWriter, r *http.Request, sessionID string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		s.errorResponse(w, http.StatusInternalServerError, "streaming unsupported")
+		return
+	}
+
+	events, unsubscribe, err := s.debateEngine.SubscribeEvents(sessionID)
+	if err != nil {
+		s.errorResponse(w, http.StatusNotFound, err.Error())
+		return
+	}
+	defer unsubscribe()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	emit := func(eventName string, payload interface{}) bool {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			log.Printf("debate event marshal error: %v", err)
+			return true
+		}
+		if _, err := fmt.Fprintf(w, "event: %s\n", eventName); err != nil {
+			return false
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", b); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	session, err := s.debateEngine.GetSession(sessionID)
+	if err != nil {
+		s.errorResponse(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if !emit("snapshot", session) {
+		return
+	}
+
+	if session.Status != debate.StatusRunning && session.Status != debate.StatusVoting {
+		return
+	}
+
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			if !emit("ping", map[string]string{"session_id": sessionID}) {
+				return
+			}
+		case event, ok := <-events:
+			if !ok {
+				return
+			}
+			if event == nil {
+				continue
+			}
+			if !emit(event.Type, event) {
+				return
+			}
+		}
 	}
 }
 
@@ -1380,12 +1820,23 @@ func (s *Server) executeDebateDecisions(session *debate.Session, decisions []*de
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Create session-specific Binance client using session's credentials
-	binanceClient := exchange.NewBinanceClient(
-		session.BinanceAPIKey,
-		session.BinanceSecretKey,
-		session.BinanceTestnet,
-	)
+	// Resolve the execution venue. When the session carries explicit venue creds,
+	// build a session-specific client from them; otherwise fall back to the server's
+	// ALREADY-ACTIVE exchange (paper-trading by default → real prices + simulated
+	// fills + no keys, or a live venue using the keys saved on the Connections page).
+	// This is what lets auto-execute actually fire after we removed the redundant
+	// credential entry from the New Council Session modal.
+	binanceClient := s.binanceClient
+	if strings.TrimSpace(session.VenueAPIKey) != "" {
+		exCfg := *s.cfg
+		exCfg.PhemexAPIKey, exCfg.PhemexSecretKey, exCfg.PhemexTestnet = session.VenueAPIKey, session.VenueSecretKey, session.VenueTestnet
+		exCfg.BinanceAPIKey, exCfg.BinanceSecretKey, exCfg.BinanceTestnet = session.VenueAPIKey, session.VenueSecretKey, session.VenueTestnet
+		c, exErr := exchange.NewExchange(&exCfg)
+		if exErr != nil {
+			return fmt.Errorf("debate exchange init: %w", exErr)
+		}
+		binanceClient = c
+	}
 
 	for _, d := range decisions {
 		if d.Action == "wait" || d.Action == "hold" {
@@ -1449,6 +1900,20 @@ func (s *Server) executeDebateDecisions(session *debate.Session, decisions []*de
 		d.ExecutedAt = time.Now()
 		d.OrderID = fmt.Sprintf("%d", order.OrderID)
 		log.Printf("[Debate] Executed order %d: %s %s %.4f @ %.2f", order.OrderID, side, d.Symbol, quantity, ticker.Price)
+
+		// Trade-Fill Linkage: a Council auto-execute is a LIVE verdict→order handoff. Link
+		// the council attribution verdict (logged at consensus) to this order. Best-effort,
+		// local-only — it never affects execution.
+		if s.attributionStore != nil {
+			if lerr := s.attributionStore.UpsertTradeLink(&store.AttributionTradeLink{
+				VerdictID: councilVerdictID(session.ID, d), LinkedVia: "explicit", LinkConfidence: "high",
+				LinkNotes: "Council auto-execute", ActionTaken: true, Actor: "council", Status: "open",
+				TraderID: session.TraderID, OrderID: d.OrderID, EntryPrice: ticker.Price, EntrySize: quantity,
+				SourceSurface: "council", SourcePersonaName: "Council", SourceProvider: "concierge",
+			}); lerr != nil {
+				log.Printf("[Attribution] council trade-link failed (%s): %v", d.Symbol, lerr)
+			}
+		}
 
 		// Place stop-loss and take-profit orders for new positions
 		if d.Action == "open_long" || d.Action == "open_short" || d.Action == "BUY" || d.Action == "SELL" {
@@ -1531,8 +1996,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		response := map[string]interface{}{
 			"settings": settings,
 			"configured": map[string]bool{
-				"openrouter": settings.OpenRouterAPIKey != "" || s.cfg.OpenRouterAPIKey != "",
-				"binance":    settings.BinanceAPIKey != "" || s.cfg.BinanceAPIKey != "",
+				"phemex": settings.PhemexAPIKey != "" || s.cfg.PhemexAPIKey != "",
 			},
 		}
 		s.jsonResponse(w, response)
@@ -1548,14 +2012,11 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		existing, _ := s.settingsStore.GetGlobalSettings()
 
 		// Only update non-masked values (if masked value sent, keep existing)
-		if isMasked(req.OpenRouterAPIKey) {
-			req.OpenRouterAPIKey = existing.OpenRouterAPIKey
+		if isMasked(req.PhemexAPIKey) {
+			req.PhemexAPIKey = existing.PhemexAPIKey
 		}
-		if isMasked(req.BinanceAPIKey) {
-			req.BinanceAPIKey = existing.BinanceAPIKey
-		}
-		if isMasked(req.BinanceSecretKey) {
-			req.BinanceSecretKey = existing.BinanceSecretKey
+		if isMasked(req.PhemexSecretKey) {
+			req.PhemexSecretKey = existing.PhemexSecretKey
 		}
 
 		if err := s.settingsStore.SaveGlobalSettings(&req); err != nil {
@@ -1578,6 +2039,56 @@ func isMasked(s string) bool {
 	return len(s) > 0 && (s == "****" || (len(s) > 8 && s[4:8] == "****"))
 }
 
+// handleFavorites persists the user's favorite symbols server-side so they survive any
+// client reset (cache clear, dev-port change, a different browser) — fixing favorites
+// being lost across restarts. Stored as a JSON string array under the generic settings
+// key "ui_favorites"; touches no secrets and places no orders.
+func (s *Server) handleFavorites(w http.ResponseWriter, r *http.Request) {
+	const key = "ui_favorites"
+	switch r.Method {
+	case "GET":
+		raw, err := s.settingsStore.Get(key)
+		if err != nil {
+			s.errorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		favorites := []string{}
+		if raw != "" {
+			_ = json.Unmarshal([]byte(raw), &favorites)
+		}
+		s.jsonResponse(w, map[string]interface{}{"favorites": favorites})
+
+	case "PUT", "POST":
+		var req struct {
+			Favorites []string `json:"favorites"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.errorResponse(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		// De-dup + drop blanks so the stored list stays clean.
+		seen := map[string]bool{}
+		clean := []string{}
+		for _, sym := range req.Favorites {
+			sym = strings.TrimSpace(sym)
+			if sym == "" || seen[sym] {
+				continue
+			}
+			seen[sym] = true
+			clean = append(clean, sym)
+		}
+		data, _ := json.Marshal(clean)
+		if err := s.settingsStore.Set(key, string(data)); err != nil {
+			s.errorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		s.jsonResponse(w, map[string]interface{}{"favorites": clean})
+
+	default:
+		s.errorResponse(w, http.StatusMethodNotAllowed, "Method not allowed")
+	}
+}
+
 // reloadConfig reloads the AI client and Binance client with new settings
 func (s *Server) reloadConfig() {
 	settings, err := s.settingsStore.GetGlobalSettings()
@@ -1586,41 +2097,28 @@ func (s *Server) reloadConfig() {
 		return
 	}
 
-	// Use DB settings if available, otherwise fall back to .env
-	apiKey := settings.OpenRouterAPIKey
-	if apiKey == "" {
-		apiKey = s.cfg.OpenRouterAPIKey
-	}
-	model := settings.OpenRouterModel
-	if model == "" {
-		model = s.cfg.OpenRouterModel
-	}
-
-	// Update AI client
-	s.aiClient = mcp.NewOpenRouterClient(apiKey, model)
+	// AI client always routes through the Quota Concierge sidecar (no key/model needed).
+	s.aiClient = mcp.NewConciergeClient(s.cfg.LLMModel)
 	s.debateEngine.RegisterClient("openrouter", s.aiClient)
 	s.debateEngine.RegisterClient("openai", s.aiClient)
 	s.debateEngine.RegisterClient("anthropic", s.aiClient)
 	s.debateEngine.RegisterClient("deepseek", s.aiClient)
 
-	// Update Binance client
-	binanceKey := settings.BinanceAPIKey
-	if binanceKey == "" {
-		binanceKey = s.cfg.BinanceAPIKey
+	// Exchange client: prefer Phemex keys from settings, else fall back to .env config.
+	exCfg := *s.cfg
+	if settings.PhemexAPIKey != "" {
+		exCfg.PhemexAPIKey = settings.PhemexAPIKey
+		exCfg.PhemexSecretKey = settings.PhemexSecretKey
+		exCfg.PhemexTestnet = settings.PhemexTestnet
 	}
-	binanceSecret := settings.BinanceSecretKey
-	if binanceSecret == "" {
-		binanceSecret = s.cfg.BinanceSecretKey
-	}
-	testnet := settings.BinanceTestnet
-	if settings.BinanceAPIKey == "" {
-		testnet = s.cfg.BinanceTestnet
+	if exch, err := exchange.NewExchange(&exCfg); err == nil {
+		s.binanceClient = exch
+		s.backtestManager = backtest.NewManager(s.aiClient, s.binanceClient)
+	} else {
+		log.Printf("Config reload: exchange init failed: %v", err)
 	}
 
-	s.binanceClient = exchange.NewBinanceClient(binanceKey, binanceSecret, testnet)
-	s.backtestManager = backtest.NewManager(s.aiClient, s.binanceClient)
-
-	log.Printf("Config reloaded: OpenRouter model=%s, Binance testnet=%v", model, testnet)
+	log.Printf("Config reloaded: exchange=%s, AI=Quota Concierge sidecar", s.cfg.Exchange)
 }
 
 // ============ SYSTEM ENDPOINTS ============


### PR DESCRIPTION
## What

Two fixes surfaced by an MRI audit of the Backtest page + a live trading-dashboard bug.

**1. Open positions hidden from dashboard** (`server/api/server.go`)
`/api/positions` read only the engine's in-memory map, returning `[]` when the engine reported none (trader stopped, freshly restarted before boot reconcile, or a transient reconcile that emptied it) — even though open positions are persisted in `trader_positions`. Added a `positionStore.GetOpenPositions` fallback with a `source` field (`engine`|`db`).

**2. Backtest page** (`client/src/pages/Backtest.tsx`)
- Equity/trade `timestamp` is unix **milliseconds**; the chart tooltip + monthly-returns bars multiplied by 1000, rendering dates ~year 58339. Removed the `×1000` and corrected the interface comments.
- `hasRunnableConfig` now also requires capital > 0, fee_bps 0–1000, slippage_bps 0–1000, leverage 1–125×. The Run button was enabled for $0 capital (backend silently reset to $10k), 999% fees, and negative slippage — all silently corrupting results.

## Note
These commits bundle pre-existing uncommitted working-tree changes in both files (shared multi-session checkout), so the diff is larger than the fixes themselves.

Steve's Automation Engine